### PR TITLE
Use pkg-config is available (Debain), yaz-config otherwise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.swp
 MYMETA.yml
+MYMETA.json
 Makefile
 Makefile.old
 ZOOM.bs

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension Net::Z3950::ZOOM.
 
+1.32  IN PROGRESS
+	- Rework ZOOM-Perl configuration to use Debian's yaz-config
+	  when pkg-config is absent. Fixes ZOOM-29.
+
 1.31  Tue Feb 21 08:46:39 UTC 2017
 	- Build for current supported Ubuntu distributions
 	- Fix some URLs in documentation

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,8 +1,10 @@
 .cvsignore
 .git
+.travis.yml
 debian
 lib/CVS
 t/CVS
+t/travis/travis-init.sh
 archive
 build-stamp
 install-stamp

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,9 +5,9 @@ use 5.008;
 use ExtUtils::MakeMaker;
 use strict;
 
-my $yazver = `pkg-config --modversion yaz` or die;
-my $yazinc = `pkg-config --cflags yaz` or die;
-my $yazlibs = `pkg-config --libs yaz` or die;
+my $yazver = `pkg-config --modversion yaz` or die $!;
+my $yazinc = `pkg-config --cflags yaz` or die $!;
+my $yazlibs = `pkg-config --libs yaz` or die $!;
 
 chomp($yazver);
 check_version($yazver, "4.0.0");

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,9 +5,27 @@ use 5.008;
 use ExtUtils::MakeMaker;
 use strict;
 
-my $yazver = `pkg-config --modversion yaz` or die $!;
-my $yazinc = `pkg-config --cflags yaz` or die $!;
-my $yazlibs = `pkg-config --libs yaz` or die $!;
+my $yazver;
+my $yazinc;
+my $yazlibs;
+system("pkg-config --exists yaz");
+if ($? == 0) {
+    $yazver = `pkg-config --modversion yaz` or die $!;
+    $yazinc = `pkg-config --cflags yaz` or die $!;
+    $yazlibs = `pkg-config --libs yaz` or die $!;
+} else {
+    $yazver = `yaz-config --version`;
+    $yazinc = `yaz-config --cflags servers`;
+    $yazlibs = `yaz-config --libs server`;
+    if (!$yazver || (!$yazinc && !$yazlibs)) {
+       die qq[
+ERROR: Unable to call script: yaz-config
+If you are using a YAZ installation from the Debian package "yaz", you
+will also need to install "libyaz-dev" in order to build the
+SimpleServer module.
+];
+   }
+}
 
 chomp($yazver);
 check_version($yazver, "4.0.0");


### PR DESCRIPTION
In commit 6f5a8c7d we changed from yaz-config (which is no longer made available by the Debian package libyaz-dev) to pkg-config (which is) -- but that doesn't work on non-Debian operating systems such as MacOS, where pkg-config is not provided. Now we back down to yaz-config when pkg-config is not available.

Fixes ZOOM-29.
